### PR TITLE
Add support for preserving timestamps for install

### DIFF
--- a/src/Cake.ProGet.Tests/Universal/Install/UniversalPackageInstallSettingsTests.cs
+++ b/src/Cake.ProGet.Tests/Universal/Install/UniversalPackageInstallSettingsTests.cs
@@ -87,5 +87,15 @@ namespace Cake.ProGet.Tests.Universal.Install
             // Then
             Assert.False(settings.Overwrite);
         }
+
+        [Fact]
+        public void PreserveTimestamps_Should_Be_False_By_Default()
+        {
+            // Given, When
+            var settings = new UniversalPackageInstallSettings("package.id", "http://proget.com/upack/feed", "./folder/test.upack");
+
+            // Then
+            Assert.False(settings.PreserveTimestamps);
+        }
     }
 }

--- a/src/Cake.ProGet.Tests/Universal/Install/UniversalPackageInstallerTests.cs
+++ b/src/Cake.ProGet.Tests/Universal/Install/UniversalPackageInstallerTests.cs
@@ -163,6 +163,21 @@ namespace Cake.ProGet.Tests.Universal.Install
         }
 
         [Theory]
+        [InlineData(true, "install Test.Package --source=http://proget.com/upack-feed --target=\"/Working/target\" --preserve-timestamps")]
+        [InlineData(false, "install Test.Package --source=http://proget.com/upack-feed --target=\"/Working/target\"")]
+        public void Should_Add_PreserveTimestamps_To_Arguments_If_Set(bool preserveTimestamps, string expected)
+        {
+            // Given
+            var fixture = new UniversalPackageInstallerFixture { Settings = { PreserveTimestamps = preserveTimestamps } };
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            Assert.Equal(expected, result.Args);
+        }
+
+        [Theory]
         [InlineData("user", "pass", "install Test.Package --source=http://proget.com/upack-feed --target=\"/Working/target\" --user=user:pass")]
         [InlineData(null, null, "install Test.Package --source=http://proget.com/upack-feed --target=\"/Working/target\"")]
         public void Should_Add_Credentials_To_Arguments_If_Set(string user, string pass, string expected)

--- a/src/Cake.ProGet/Universal/Install/UniversalPackageInstallSettings.cs
+++ b/src/Cake.ProGet/Universal/Install/UniversalPackageInstallSettings.cs
@@ -90,6 +90,14 @@ namespace Cake.ProGet.Universal.Install
         public bool Overwrite { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether timestamps of installed files should be preserved as in the package.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if timestamps should be preserved; otherwise, <c>false</c>.
+        /// </value>
+        public bool PreserveTimestamps { get; set; }
+
+        /// <summary>
         /// Gets whether or not credentials are specified
         /// </summary>
         /// <returns>

--- a/src/Cake.ProGet/Universal/Install/UniversalPackageInstaller.cs
+++ b/src/Cake.ProGet/Universal/Install/UniversalPackageInstaller.cs
@@ -69,6 +69,11 @@ namespace Cake.ProGet.Universal.Install
                 builder.Append("--overwrite");
             }
 
+            if (settings.PreserveTimestamps)
+            {
+                builder.Append("--preserve-timestamps");
+            }
+
             if (settings.HasCredentials())
             {
                 if (!settings.AreCredentialsValid())


### PR DESCRIPTION
This exposes the upack.exe install parameter --preserve-timestamps that will allow installing a upack without changing the timestamps of the contained files.

I have used the --overwrite parameter for inspiration as it has the same footprint in the code.